### PR TITLE
fix: apprentice_invert_selection not working

### DIFF
--- a/lua/apprentice/base.lua
+++ b/lua/apprentice/base.lua
@@ -87,7 +87,6 @@ local color_column = utils.get_color_from_var(vim.g.apprentice_color_column, bg1
 local vert_split = utils.get_color_from_var(vim.g.apprentice_vert_split, bg0, colors)
 local win_separator = utils.get_color_from_var(vim.g.apprentice_win_separator, bg0, colors)
 local tabline_sel = utils.get_color_from_var(vim.g.apprentice_tabline_sel, blue, colors)
-local sign_column = utils.get_color_from_var(vim.g.apprentice_sign_column, bg1, colors)
 
 local improved_strings_fg = fg1
 local improved_strings_bg = bg1
@@ -105,9 +104,11 @@ if not utils.tobool(vim.g.apprentice_improved_strings) then
 end
 
 local background = nil
+local sign_column = nil
 
 if not utils.tobool(vim.g.apprentice_transparent_bg) then
   background = bg0
+  sign_column = utils.get_color_from_var(vim.g.apprentice_sign_column, bg1, colors)
 end
 
 -- neovim terminal mode colors
@@ -224,7 +225,7 @@ local base_group = lush(function()
     TabLine { fg = bg4, bg = bg1, gui = styles.invert_tabline },
     TabLineSel { fg = tabline_sel, bg = bg1, gui = styles.invert_tabline },
     Title { fg = fg0, gui = styles.bold },
-    Visual { bg = bg4 },
+    Visual { bg = bg1, gui = styles.invert_selection },
     VisualNOS { Visual },
     -- WarningMsg {ApprenticeRedBold},
     WildMenu { fg = blue, bg = bg2, gui = styles.bold },

--- a/lua/apprentice/base.lua
+++ b/lua/apprentice/base.lua
@@ -225,7 +225,7 @@ local base_group = lush(function()
     TabLine { fg = bg4, bg = bg1, gui = styles.invert_tabline },
     TabLineSel { fg = tabline_sel, bg = bg1, gui = styles.invert_tabline },
     Title { fg = fg0, gui = styles.bold },
-    Visual { bg = bg1, gui = styles.invert_selection },
+    Visual { bg = bg4, gui = styles.invert_selection },
     VisualNOS { Visual },
     -- WarningMsg {ApprenticeRedBold},
     WildMenu { fg = blue, bg = bg2, gui = styles.bold },

--- a/lua/apprentice/settings.lua
+++ b/lua/apprentice/settings.lua
@@ -24,10 +24,10 @@ local styles = {
   italic = "italic",
   bold = "bold",
   underline = "underline",
-  inverse = "inverse",
+  inverse = "reverse",
   undercurl = "undercurl",
   invert_signs = "",
-  invert_selection = "inverse",
+  invert_selection = "reverse",
   invert_tabline = "",
   italic_comments = "italic",
   italic_booleans = "NONE",
@@ -68,7 +68,7 @@ if not utils.tobool(vim.g.apprentice_undercurl) then
 end
 
 if utils.tobool(vim.g.apprentice_invert_signs) then
-  styles.invert_signs = "inverse"
+  styles.invert_signs = "reverse"
 end
 
 if not utils.tobool(vim.g.apprentice_invert_selection) then
@@ -76,7 +76,7 @@ if not utils.tobool(vim.g.apprentice_invert_selection) then
 end
 
 if utils.tobool(vim.g.apprentice_invert_tabline) then
-  styles.invert_tabline = "inverse"
+  styles.invert_tabline = "reverse"
 end
 
 if not utils.tobool(vim.g.apprentice_italicize_comments) then


### PR DESCRIPTION
Fix invert keyword "inverse" not working in Lush. Changed to "reverse".
Ref: [Lush docs](https://github.com/rktjmp/lush.nvim/blob/main/doc/lush.txt) :322
Fix apprentice_invert_selection -> `styles.invert_selection` not applied to Visual.
Fix sign_column NOT transparent when `apprentice_transparent_bg` true